### PR TITLE
Fix truncateFilter for string shorter than numberOfCharacters

### DIFF
--- a/Sources/Spelt/Stencil+Spelt.swift
+++ b/Sources/Spelt/Stencil+Spelt.swift
@@ -173,8 +173,10 @@ func truncateFilter(_ value: Any?, arguments: [Any?]) throws -> Any? {
         throw TemplateSyntaxError("'truncate' filter expects integer argument")
     }
     
-    let endIndex = string.characters.index(string.startIndex, offsetBy: numberOfCharacters, limitedBy: string.endIndex)
-    return string[string.startIndex..<endIndex!]
+    guard let endIndex = string.characters.index(string.startIndex, offsetBy: numberOfCharacters, limitedBy: string.endIndex) else {
+        return string
+    }
+    return string[string.startIndex..<endIndex]
 }
 
 func joinFilter(_ value: Any?, arguments: [Any?]) throws -> Any? {


### PR DESCRIPTION
`truncateFilter` will be crashed if `string` is shorter than `numberOfCharacters`.
I changed it so that it returns `string` unchanged in such a case.